### PR TITLE
Render the Poui component with choice alternatives

### DIFF
--- a/app/controllers/choices_controller.rb
+++ b/app/controllers/choices_controller.rb
@@ -1,9 +1,12 @@
+require 'choice/parto_coding'
+
 class ChoicesController < ApplicationController
 
   # GET /choices/1
   def show
     @choice = Choice.find_by(read_token: params[:id])
     head :not_found unless @choice
+    @choice.extend(Choice::PartoCoding)
   end
 
   # GET /choices/new

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -13,7 +13,17 @@ class PreferencesController < ApplicationController
   def create
     @choice = Choice.find_by(read_token: choice_params[:read_token])
     return head :bad_request unless @choice
-    alternative = @choice.alternatives.find(alternative_param)
+    if (params[:alternative])
+      alternative = @choice.alternatives.find(alternative_param)
+    elsif (choice_params[:parto])
+      parto = choice_params[:parto]
+      parto = JSON.parse(choice_params[:parto])
+      first = parto[0]
+      first = first[0] if (first.kind_of? Array)
+      alternative = @choice.alternatives.find(first);
+    else
+      return head :bad_request
+    end
     preference = build_select_alternative_preference(@choice, alternative)
     derive_chef_to_preference(preference, request)
 
@@ -25,7 +35,7 @@ class PreferencesController < ApplicationController
   end
 
   def choice_params
-    params.require(:choice).permit(:read_token) do |cp|
+    params.require(:choice).permit(:read_token, :parto) do |cp|
       cp.require(:read_token)
     end
   end

--- a/app/models/choice/parto_coding.rb
+++ b/app/models/choice/parto_coding.rb
@@ -1,0 +1,10 @@
+# Use this module to extend a choice with Parto encoding and decoding behavior
+
+module Choice::PartoCoding
+  # Build and retern a JSON object with an array keys and descriptions
+  def parto_encoding
+    alternatives.collect do |alt|
+      { key: alt.id.to_s, description: alt.title }
+    end
+  end
+end

--- a/app/views/choices/_selection.html.erb
+++ b/app/views/choices/_selection.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag preferences_path do %>
   <%= hidden_field :choice, :read_token %>
-  <%= render 'selectionRankPartial' %>
+  <%= render 'selectionRankPartial', locals: { choice: @choice } %>
   <div class="actions">
     <%= submit_tag 'Submit preference' %>
   </div>

--- a/app/views/choices/_selectionRankPartial.html.erb
+++ b/app/views/choices/_selectionRankPartial.html.erb
@@ -1,13 +1,6 @@
-<% items = [
-     { key: 'A', description: 'Ace' },
-     { key: 'B', description: 'Box' },
-     { key: 'C', description: 'Cat' },
-     { key: 'D', description: 'Dig' }
-   ].to_json
-%>
 <div
   class="poui-entry"
   data-poui-field="choice[parto]"
-  data-poui-items="<%= items %>"
+  data-poui-items="<%= @choice.parto_encoding.to_json %>"
   data-poui-parto="[]"
 ></div>

--- a/test/controllers/preferences_controller_test.rb
+++ b/test/controllers/preferences_controller_test.rb
@@ -6,8 +6,16 @@ class PreferencesControllerTest < ActionDispatch::IntegrationTest
     @choice.save!
   end
 
-  test 'should post selection by read token' do
+  test 'posts selection' do
     params = selection_params(@choice)
+    post preferences_path, params: params
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+  end
+
+  test 'posts partial ordering' do
+    params = parto_selection_params(@choice)
     post preferences_path, params: params
     assert_response :redirect
     follow_redirect!

--- a/test/helpers/choice_helper.rb
+++ b/test/helpers/choice_helper.rb
@@ -47,6 +47,17 @@ module ChoiceHelper
       commit: 'Submit preference',
     }
   end
+
+  def parto_selection_params(choice, alt_id = nil)
+    alt_id ||= choice.alternatives[rand(choice.alternatives.count)].id
+    {
+      choice: {
+        read_token: choice.read_token,
+        parto: [alt_id.to_s, []].to_json
+      },
+      commit: 'Submit preference',
+    }
+  end
 end
 
 class ActiveSupport::TestCase

--- a/test/integration/choice/selection_rank_partial_test.rb
+++ b/test/integration/choice/selection_rank_partial_test.rb
@@ -1,0 +1,33 @@
+# Test display of choice alternatives for
+# expression of preference by partial ordering
+require 'test_helper'
+
+class SelectionRankPartialTest < ActionDispatch::IntegrationTest
+  setup do
+    @choice = create_full_choice
+    @choice.save!
+    get choice_path(@choice.read_token)
+    assert_response :success
+  end
+
+  test "has choice identified" do
+    assert_select("input[name='choice[read_token]']") do
+      assert_select("input[value='#{@choice.read_token}']");
+    end
+  end
+
+  test "has stem" do
+    assert_select('div[class="choiceTitle"]', @choice.title)
+  end
+
+  test "has parto input" do
+    assert_select('div[data-poui-field="choice[parto]"]')
+  end
+
+  test "has alternatives" do
+    @choice.alternatives.each do |alt|
+      assert_select("div:match('data-poui-items', ?)", /#{alt.id}/)
+      assert_select("div:match('data-poui-items', ?)", /#{alt.title}/)
+    end
+  end
+end

--- a/test/models/choice/parto_coding_test.rb
+++ b/test/models/choice/parto_coding_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'choice/parto_coding'
+
+class PartoCodingTest < ActiveSupport::TestCase
+  setup do
+    @choice = create_full_choice
+    @choice.save!
+    @choice.extend(Choice::PartoCoding)
+    @parto = @choice.parto_encoding
+  end
+
+  test "encodes choice alternatives" do
+    assert(@parto.kind_of?(Array))
+    assert_equal(@choice.alternatives.count, @parto.length)
+    @choice.alternatives.each do |alt|
+      assert(@parto.include?({ key: alt.id.to_s, description: alt.title }))
+    end
+  end
+end

--- a/test/system/choice_confirm_test.rb
+++ b/test/system/choice_confirm_test.rb
@@ -6,9 +6,6 @@ class ChoiceConfirmTest < ApplicationSystemTestCase
     @choice.save!
     @alternative = @choice.alternatives.first
     visit choice_path(@choice.read_token)
-    radio = find(:xpath,
-      "//form/dl[@class='alternatives']//input[@value='#{@alternative.id}']")
-    radio.click
     click_on "Submit preference"
   end
 


### PR DESCRIPTION
Part of #9 

This encodes the alternatives of a choice into the Poui component rendered in the "show" view of a choice.

It also enables the system test for preference submission to work, although the preferences controller now temporarily cheats.