### PR TITLE
Show partial order in choice confirmation

### DIFF
--- a/app/assets/javascripts/parceled/index.js
+++ b/app/assets/javascripts/parceled/index.js
@@ -2302,6 +2302,50 @@ function withInput(Wrapped) {
 
 var _default = PouiInput;
 exports.default = _default;
+},{"react":"1n8/","react-dom":"NKHc","prop-types":"5D9O","poui":"9WA7"}],"aKzs":[function(require,module,exports) {
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireWildcard(require("react"));
+
+var _reactDom = _interopRequireDefault(require("react-dom"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _poui = require("poui");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+function populatePartoDisplay() {
+  var parto_divs = document.querySelectorAll('[data-parto-display]');
+  parto_divs.forEach(function (parto_div) {
+    var field_list = parto_div.getAttribute('data-parto-items');
+
+    if (typeof field_list === "string") {
+      field_list = JSON.parse(field_list);
+    }
+
+    var field_value = parto_div.getAttribute('data-parto-display') || [];
+
+    if (typeof field_value === "string") {
+      field_value = JSON.parse(field_value);
+    }
+
+    _reactDom.default.render(_react.default.createElement(_poui.Parto, {
+      itemList: field_list,
+      parto: field_value
+    }), parto_div);
+  });
+}
+
+var _default = populatePartoDisplay;
+exports.default = _default;
 },{"react":"1n8/","react-dom":"NKHc","prop-types":"5D9O","poui":"9WA7"}],"Focm":[function(require,module,exports) {
 "use strict";
 
@@ -2314,6 +2358,8 @@ var _reactSimpleTimefield = _interopRequireDefault(require("react-simple-timefie
 var _time_input = _interopRequireDefault(require("./time_input"));
 
 var _poui_input = _interopRequireDefault(require("./poui_input"));
+
+var _parto_display = _interopRequireDefault(require("./parto_display"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -2342,6 +2388,7 @@ function populatePoui() {
 
 document.addEventListener("DOMContentLoaded", function () {
   populatePoui();
+  (0, _parto_display.default)();
   var time_fields = document.querySelectorAll('[data-time-field]');
   var now = new Date();
   var initial = now.getHours() + ":" + now.getMinutes();
@@ -2361,4 +2408,4 @@ document.addEventListener("DOMContentLoaded", function () {
 }, {
   "once": true
 });
-},{"react":"1n8/","react-dom":"NKHc","react-simple-timefield":"93L1","./time_input":"aPBd","./poui_input":"Ar8f"}]},{},["Focm"], null)
+},{"react":"1n8/","react-dom":"NKHc","react-simple-timefield":"93L1","./time_input":"aPBd","./poui_input":"Ar8f","./parto_display":"aKzs"}]},{},["Focm"], null)

--- a/app/controllers/concerns/preference_expression.rb
+++ b/app/controllers/concerns/preference_expression.rb
@@ -35,4 +35,32 @@ module PreferenceExpression
     end
     preference
   end
+
+  def decode_group(group)
+    if group.length == 1
+      group[0].alternative.id.to_s
+    else
+      group.collect do |xpr|
+        xpr.alternative.id.to_s
+      end
+    end
+  end
+
+  def parto_expression(preference)
+    pexpr = []
+    group = []
+    last_rank = 0
+    preference.expressions.includes(:alternative)
+        .order(:sequence).each do |expr|
+      if (expr.sequence != last_rank && !group.empty?)
+        pexpr << decode_group(group)
+        group = [expr]
+      else
+        group << expr
+      end
+      last_rank = expr.sequence
+    end
+    pexpr << decode_group(group)
+    pexpr.to_json
+  end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -1,3 +1,5 @@
+require 'choice/parto_coding'
+
 class PreferencesController < ApplicationController
   include PreferenceExpression
 
@@ -5,8 +7,9 @@ class PreferencesController < ApplicationController
   def show
     @preference = Preference.find_by(token: params[:id])
     return head :not_found unless @preference
+    @parto = parto_expression(@preference)
     @choice = @preference.choice
-    @alternative = @preference.expressions[0].alternative
+    @choice.extend(Choice::PartoCoding)
   end
 
   # POST /preferences/create

--- a/app/views/preferences/show.html.erb
+++ b/app/views/preferences/show.html.erb
@@ -1,10 +1,13 @@
 <h1>Your selection</h1>
 
 <p>You selected:
-  <span class='alternative-title'><%= @alternative.title %></span>
+  <div
+    data-parto-display=<%= @parto %>
+    data-parto-items="<%= @choice.parto_encoding.to_json %>"
+  ></div>
 </p>
 
-<p>The link for viewing the result will be:</p>
+<p>The link for viewing the result is:</p>
 <p>
   <%= link_to("View result of choice, #{@choice.title}",
     result_choice_path(@choice.read_token), class: 'displayLink')

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import TimeField from "react-simple-timefield";
 import TimeInputElement from "./time_input";
 import PouiInput from "./poui_input";
+import populatePartoDisplay from "./parto_display"
 
 function populatePoui() {
   const poui_fields = document.querySelectorAll('[data-poui-field]');
@@ -26,6 +27,7 @@ function populatePoui() {
 
 document.addEventListener("DOMContentLoaded", function() {
   populatePoui();
+  populatePartoDisplay();
   const time_fields = document.querySelectorAll('[data-time-field]');
   const now = new Date();
   const initial = now.getHours() + ":" + now.getMinutes();

--- a/src/parto_display.js
+++ b/src/parto_display.js
@@ -1,0 +1,22 @@
+import React, { Component } from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
+import { Parto } from "poui";
+
+function populatePartoDisplay() {
+  const parto_divs = document.querySelectorAll('[data-parto-display]');
+  parto_divs.forEach((parto_div) => {
+    let field_list = parto_div.getAttribute('data-parto-items');
+    if (typeof field_list === "string") {
+      field_list = JSON.parse(field_list);
+    }
+    let field_value = parto_div.getAttribute('data-parto-display') || [];
+    if (typeof field_value === "string") {
+      field_value = JSON.parse(field_value);
+    }
+    ReactDOM.render(<Parto itemList={field_list} parto={field_value} />,
+      parto_div);
+  });
+}
+
+export default populatePartoDisplay;

--- a/test/integration/parto_display_test.rb
+++ b/test/integration/parto_display_test.rb
@@ -1,0 +1,30 @@
+# Test view preference by partial ordering
+require 'test_helper'
+
+class PartoDisplayTest < ActionDispatch::IntegrationTest
+  setup do
+    @choice = create_choice("#{Faker::Book.author} books")
+    build_alternatives(@choice, 12)
+    @choice.save!
+    post preferences_path(parto_selection_params(@choice))
+    assert_response :redirect
+    follow_redirect!
+  end
+
+  test "post redirects to view" do
+    assert_response :success
+    assert_select('div[data-parto-display]')
+  end
+
+  test "view contains items" do
+    assert_response :success
+    assert_select('div[data-parto-display]') do
+      assert_select('div[data-parto-items]')
+      @choice.alternatives.each do |alt|
+        assert_select("div:match('data-parto-display', ?)", /#{alt.id}/)
+        assert_select("div:match('data-parto-items', ?)", /#{alt.id}/)
+        assert_select("div:match('data-parto-items', ?)", /#{alt.title}/)
+      end
+    end
+  end
+end

--- a/test/system/choice_confirm_test.rb
+++ b/test/system/choice_confirm_test.rb
@@ -4,13 +4,15 @@ class ChoiceConfirmTest < ApplicationSystemTestCase
   setup do
     @choice = create_full_choice
     @choice.save!
-    @alternative = @choice.alternatives.first
     visit choice_path(@choice.read_token)
     click_on "Submit preference"
   end
 
   test "confirm shows choice" do
-    assert_text("You selected: #{@alternative.title}")
+    assert_text("You selected:")
+    @choice.alternatives.each do |alt|
+      assert_text(alt.title)
+    end
   end
 
   test "confirm shows results link" do


### PR DESCRIPTION
Part of #9 

Display the partial order for an individual ranking. We do this by rendering a div containing the `parto` expression and item list as `data-` attributes. We added javascript to decorate those with the `Parto` react component.