### PR TITLE
Randomize initial order of alternatives

### DIFF
--- a/app/assets/javascripts/parceled/index.js
+++ b/app/assets/javascripts/parceled/index.js
@@ -1461,9 +1461,11 @@ var PartialOrder = {
   // Returns a new order with groups containing only one item replaced with
   //   the item
   flattenSoloGroups: function flattenSoloGroups(order) {
-    return order.map(function (key) {
+    var flat = order.map(function (key) {
       if (Array.isArray(key)) {
-        if (key.length == 1) {
+        if (key.length == 0) {
+          return null;
+        } else if (key.length == 1) {
           return key[0];
         } else {
           return key;
@@ -1471,6 +1473,9 @@ var PartialOrder = {
       } else {
         return key;
       }
+    });
+    return flat.filter(function (key) {
+      return key != null;
     });
   },
   // Returns a new order arranged according to the given order, with
@@ -1483,7 +1488,7 @@ var PartialOrder = {
     var rest = keys.filter(function (key) {
       return !included.includes(key);
     });
-    return PartialOrder.flattenSoloGroups(cleanOrder).concat([rest]);
+    return PartialOrder.flattenSoloGroups(cleanOrder.concat([rest]));
   },
   // Return a new group with item and given index removed
   shallowRemoveItem: function shallowRemoveItem(group, index) {
@@ -2243,11 +2248,12 @@ function withInput(Wrapped) {
       _classCallCheck(this, WithInput);
 
       _this = _possibleConstructorReturn(this, _getPrototypeOf(WithInput).call(this, props));
+
+      _defineProperty(_assertThisInitialized(_this), "state", {
+        ordering: _this.props.parto
+      });
+
       _this.updateOrdering = _this.updateOrdering.bind(_assertThisInitialized(_this));
-      var ordering = props.parto;
-      _this.state = {
-        ordering: _poui.PartialOrder.encompassItems(props.itemList, ordering)
-      };
       return _this;
     }
 

--- a/app/models/choice/parto_coding.rb
+++ b/app/models/choice/parto_coding.rb
@@ -1,10 +1,20 @@
 # Use this module to extend a choice with Parto encoding and decoding behavior
 
 module Choice::PartoCoding
-  # Build and retern a JSON object with an array keys and descriptions
-  def parto_encoding
-    alternatives.collect do |alt|
+  # Build and retern a JSON string with an array keys and descriptions
+  def parto_items_encoding
+    items = alternatives.collect do |alt|
       { key: alt.id.to_s, description: alt.title }
     end
+    items.to_json
+  end
+
+  # Build and return a JSON string representing a parto
+  # with items ranked together in random sequence
+  def parto_random_initial
+    keys = alternatives.collect do |alt|
+      alt.id.to_s
+    end
+    [keys.shuffle].to_json
   end
 end

--- a/app/views/choices/_selectionRankPartial.html.erb
+++ b/app/views/choices/_selectionRankPartial.html.erb
@@ -1,6 +1,6 @@
 <div
   class="poui-entry"
   data-poui-field="choice[parto]"
-  data-poui-items="<%= @choice.parto_encoding.to_json %>"
-  data-poui-parto="[]"
+  data-poui-items="<%= @choice.parto_items_encoding %>"
+  data-poui-parto="<%= @choice.parto_random_initial %>"
 ></div>

--- a/app/views/choices/result.html.erb
+++ b/app/views/choices/result.html.erb
@@ -11,7 +11,7 @@
 <% else %>
   <div
     data-parto-display=<%= @parto %>
-    data-parto-items="<%= @choice.parto_encoding.to_json %>"
+    data-parto-items="<%= @choice.parto_items_encoding %>"
   ></div>
 <% end %>
 

--- a/app/views/preferences/show.html.erb
+++ b/app/views/preferences/show.html.erb
@@ -3,7 +3,7 @@
 <p>You selected:
   <div
     data-parto-display=<%= @parto %>
-    data-parto-items="<%= @choice.parto_encoding.to_json %>"
+    data-parto-items="<%= @choice.parto_items_encoding %>"
   ></div>
 </p>
 

--- a/src/poui_input.js
+++ b/src/poui_input.js
@@ -14,13 +14,13 @@ function withInput(Wrapped) {
       inputClass: PropTypes.string
     }
 
+    state = {
+      ordering: this.props.parto
+    }
+
     constructor(props) {
       super(props);
       this.updateOrdering = this.updateOrdering.bind(this);
-      const ordering = props.parto;
-      this.state = {
-        ordering: PartialOrder.encompassItems(props.itemList, ordering),
-      };
     }
 
     updateOrdering(updatedOrdering) {

--- a/test/models/choice/parto_coding_test.rb
+++ b/test/models/choice/parto_coding_test.rb
@@ -6,14 +6,17 @@ class PartoCodingTest < ActiveSupport::TestCase
     @choice = create_full_choice
     @choice.save!
     @choice.extend(Choice::PartoCoding)
-    @parto = @choice.parto_encoding
+    @parto = @choice.parto_items_encoding
   end
 
   test "encodes choice alternatives" do
-    assert(@parto.kind_of?(Array))
-    assert_equal(@choice.alternatives.count, @parto.length)
+    assert(@parto.kind_of?(String))
+    encoded_items = JSON.parse(@parto)
+    assert(encoded_items.kind_of?(Array))
+    assert_equal(@choice.alternatives.count, encoded_items.length)
     @choice.alternatives.each do |alt|
-      assert(@parto.include?({ key: alt.id.to_s, description: alt.title }))
+      item = { "key" => alt.id.to_s, "description" => alt.title }
+      assert(encoded_items.include?(item))
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,9 +4252,9 @@ posthtml@^0.11.2, posthtml@^0.11.3:
     posthtml-render "^1.1.5"
 
 poui@^1.0.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/poui/-/poui-1.2.1.tgz#fa6712a725f5790e8b87293b8f9fc885ed7006af"
-  integrity sha512-y24HSSIbPtiCJnEhu7piISgejKZhCPmkpqNrTAnlIN81NcLdhJdya1rgAdPQ9DXmYUBWQpQjjb/snGCssOcp3Q==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/poui/-/poui-1.2.2.tgz#d30ee9c0d6a95dbb88208b76f94368aa84505fea"
+  integrity sha512-pmWB6+n5VFflvN3JqDANZP4U8Gj+kGtXFyafEWouA1Ar9hEYRG3JzqJ3fu24jyallntHq2hMCHO/2/jyY8mfLg==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Part of #9

Rather than showing alternatives always in the same order, show them initially in a randomized order. This attempts to spread the bias given the first show items across all responses.

This uncovered a bug in poui, which is repaired and a new version pulled.

I also took the chance to precode the return from `parto_encoding` as JSON, rather than calling `to_json` on it everywhere, and renamed it to `parto_items_encoding` for good measure.