### PR TITLE
Enable view of choice intermediate result (before choice closes)

### DIFF
--- a/app/controllers/choices_controller.rb
+++ b/app/controllers/choices_controller.rb
@@ -65,6 +65,7 @@ class ChoicesController < ApplicationController
       :title, :description,
       :opening_date, :opening_time,
       :deadline_date, :deadline_time,
+      :intermediate,
       alternatives_attributes: [ :id, :title, :description, :_destroy ]
     )
   end

--- a/app/views/choices/_display.html.erb
+++ b/app/views/choices/_display.html.erb
@@ -11,4 +11,4 @@
     </div>
   <% end %>
 </div>
-<%= render :partial => 'options' %>
+<%= render :partial => 'choices/options' %>

--- a/app/views/choices/_display.html.erb
+++ b/app/views/choices/_display.html.erb
@@ -11,3 +11,4 @@
     </div>
   <% end %>
 </div>
+<%= render :partial => 'options' %>

--- a/app/views/choices/_form.html.erb
+++ b/app/views/choices/_form.html.erb
@@ -18,6 +18,12 @@
       locals: { form: f, field: 'deadline', value: @choice.deadline } %>
   </div>
 
+  <h3>Options</h3>
+  <div id='options'>
+    <%= f.check_box :intermediate %>
+    <%= f.label :intermediate, 'Show intermediate result' %>
+  </div>
+
   <div class="actions">
     <%= f.submit 'Publish' %>
   </div>

--- a/app/views/choices/_options.html.erb
+++ b/app/views/choices/_options.html.erb
@@ -1,0 +1,9 @@
+<ul>
+  <li>
+    <% if @choice.intermediate %>
+      Will show intermediate results
+    <% else %>
+      Results hidden until choice closes
+    <% end %>
+  </li>
+</ul>

--- a/app/views/choices/result.html.erb
+++ b/app/views/choices/result.html.erb
@@ -4,11 +4,21 @@
 
 <% now = Time.now %>
 <% deadline = @choice.deadline || now %>
-<% if now < deadline %>
-  <p>Results of this choice will become available in
+
+<p>
+  <% if now < deadline %>
+    <% if @choice.intermediate %>
+      Intermediate results. This choice will close in
+    <% else %>
+      Results of this choice will become available in
+    <% end %>
     <%= distance_of_time_in_words(now, deadline) %>
-  </p>
-<% else %>
+  <% else %>
+    This choice has closed to further responses.
+  <% end %>
+</p>
+
+<% if deadline < now || @choice.intermediate %>
   <div
     data-parto-display=<%= @parto %>
     data-parto-items="<%= @choice.parto_items_encoding %>"

--- a/app/views/choices/result.html.erb
+++ b/app/views/choices/result.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 </p>
 
-<% if deadline < now || @choice.intermediate %>
+<% if deadline <= now || @choice.intermediate %>
   <div
     data-parto-display=<%= @parto %>
     data-parto-items="<%= @choice.parto_items_encoding %>"

--- a/db/migrate/20190722175628_add_intermediate_to_choice.rb
+++ b/db/migrate/20190722175628_add_intermediate_to_choice.rb
@@ -1,0 +1,5 @@
+class AddIntermediateToChoice < ActiveRecord::Migration[5.2]
+  def change
+    add_column(:choices, :intermediate, :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_15_190020) do
+ActiveRecord::Schema.define(version: 2019_07_22_175628) do
 
   create_table "alternatives", force: :cascade do |t|
     t.string "title", limit: 256, null: false
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_06_15_190020) do
     t.datetime "updated_at"
     t.string "read_token", limit: 32
     t.string "edit_token", limit: 32
+    t.boolean "intermediate", default: false, null: false
     t.index ["edit_token"], name: "index_choices_on_edit_token", unique: true
     t.index ["read_token"], name: "index_choices_on_read_token", unique: true
   end

--- a/test/helpers/choice_helper.rb
+++ b/test/helpers/choice_helper.rb
@@ -1,10 +1,11 @@
 module ChoiceHelper
   def create_choice(attribs={})
-    title = attribs.fetch(:title, nil)
-    title ||= Faker::Book.unique.title
-    description = attribs.fetch(:description, nil)
-    description ||= Faker::Quote.yoda
-    Choice.new(title: title, description: description)
+    title = attribs.fetch(:title, nil) || Faker::Book.unique.title
+    description = attribs.fetch(:description, nil) || Faker::Quote.yoda
+    intermediate = attribs.fetch(:intermediate, false)
+    Choice.new(
+      title: title, description: description, intermediate: intermediate
+    )
   end
 
   def build_alternatives(choice, count=2)
@@ -35,6 +36,7 @@ module ChoiceHelper
         deadline_time: choice.deadline.to_time,
         edit_token: choice.edit_token,
         read_token: choice.read_token,
+        intermediate: choice.intermediate,
         alternatives_attributes: choice.alternatives.collect do |alt|
           {
             title: alt.title,

--- a/test/integration/choice/create_test.rb
+++ b/test/integration/choice/create_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class Choice::CreateTest < ActionDispatch::IntegrationTest
+  test 'records opt-in for show intermediate results' do
+    get new_choice_path
+    assert_response :success
+    assert_select 'h3', 'Options'
+    assert_select 'input[name="choice[intermediate]"]'
+    choice = create_full_choice(intermediate: true)
+    post choices_path(params: choice_params(choice))
+    assert_response :redirect
+    follow_redirect!
+    assert_select 'li', 'Will show intermediate results'
+  end
+
+  test 'reverses opt-in for show intermediate results' do
+    choice = create_full_choice(intermediate: true)
+    choice.save!
+    get edit_choice_path(id: choice.edit_token)
+    assert_response :success
+    choice.intermediate = false
+    post choices_path(params: choice_params(choice))
+    assert_response :redirect
+    follow_redirect!
+    assert_select 'li', 'Results hidden until choice closes'
+  end
+end

--- a/test/integration/choice/result_test.rb
+++ b/test/integration/choice/result_test.rb
@@ -21,7 +21,7 @@ class Choice::ResultTest < ActionDispatch::IntegrationTest
   end
 
   test 'displays closed when closing time has passed' do
-    travel_to(@choice.deadline + 1.second) do
+    travel_to(@choice.deadline) do
       get result_choice_path(id: @choice.read_token)
       assert_response :success
       assert_select('p', /This choice has closed to further responses/)

--- a/test/integration/choice/result_test.rb
+++ b/test/integration/choice/result_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Choice::ResultTest < ActionDispatch::IntegrationTest
+  setup do
+    @choice = create_full_choice
+    @choice.save
+  end
+
+  test 'displays intermediate result when enabled' do
+    @choice.update_attributes(intermediate: true)
+    get result_choice_path(id: @choice.read_token)
+    assert_response :success
+    assert_select('div[data-parto-items]')
+  end
+
+  test 'displays future closing time when intermediate enabled' do
+    @choice.update_attributes(intermediate: true)
+    get result_choice_path(id: @choice.read_token)
+    assert_response :success
+    assert_select('p', /Intermediate results. This choice will close in/)
+  end
+
+  test 'displays closed when closing time has passed' do
+    travel_to(@choice.deadline + 1.second) do
+      get result_choice_path(id: @choice.read_token)
+      assert_response :success
+      assert_select('p', /This choice has closed to further responses/)
+    end
+  end
+
+  test 'displays closing time when intermediate result disabled' do
+    get result_choice_path(id: @choice.read_token)
+    assert_response :success
+    assert_select('p', /Results of this choice will become available in/)
+  end
+end


### PR DESCRIPTION
Currently the results link only shows a result after the choice closes. With opt-in, show intermediate results at that link.

- Add new intermediate boolean column to choices.
- Populate it with false, by default
- Place opt-in on choice create and edit forms
- Show intermediate result on results page if enabled

Closes #15 