### PR TITLE
Allow shorter alternative titles

### DIFF
--- a/app/models/concerns/validTitleDescription.rb
+++ b/app/models/concerns/validTitleDescription.rb
@@ -7,27 +7,36 @@ module TitleDescriptionValidation
 
   MIN_LENGTH = 6
   MIN_LENGTH_WORD = 'six'
+  SINO_MIN_LENGTH = 2
+  SINO_MIN_LENGTH_WORD = 'two'
 
   def valid_title_and_description_allow_yes_no
-    valid_title_and_description_lengths(true)
+    do_valid_title_and_description_lengths(
+      SINO_MIN_LENGTH, SINO_MIN_LENGTH_WORD)
   end
 
   def valid_title_and_description_lengths(sino = false)
+    do_valid_title_and_description_lengths(
+      MIN_LENGTH, MIN_LENGTH_WORD)
+  end
+
+  def do_valid_title_and_description_lengths(min_length, min_length_word)
     checklen = false
-    if title.length < MIN_LENGTH && !(sino && (/^(yes|no)$/i =~ title))
+    if title.length < min_length
       if description.empty?
          if title.empty?
            errors[:base] << 'Title or description must contain some text'
          else
            checklen = true;
          end
-      elsif description.length < MIN_LENGTH
+      elsif description.length < min_length
          checklen = true;
       end
     end
     if checklen
-      errors[:base] << 
-        "Provide at least #{MIN_LENGTH_WORD} characters for title or description"
+      errors[:base] <<
+        "Provide at least #{min_length_word}"\
+        " characters for title or description"
     end
   end
 

--- a/test/models/alternative_test.rb
+++ b/test/models/alternative_test.rb
@@ -1,8 +1,27 @@
 require 'test_helper'
 
 class AlternativeTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
+  setup do
+    @choice = create_full_choice
+  end
+
+  test 'validates non-empty title or description' do
+    @choice.alternatives.build(title: '', description: '')
+    assert_invalid_record(@choice,
+      /Title or description must contain some text/)
+  end
+
+  test 'validates title length' do
+    @choice.alternatives.build(title: 'A', description: '')
+    assert_invalid_record(@choice,
+      /Provide at least .+ characters for title or description/)
+  end
+
+  test 'allows short alternative titles' do
+    @choice.alternatives.build(title: 'Beer')
+    @choice.alternatives.build(title: 'Pizza')
+    @choice.alternatives.build(title: 'Ale')
+    @choice.alternatives.build(title: 'Fainá')
+    assert(@choice.save)
   end
 end


### PR DESCRIPTION
Closes #18 

Reduces minimum title length, for alternatives only, to two.