### PR TITLE
Set and verify setting opening and deadline on choice create

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :test do
   gem 'faker'
   gem 'launchy'
   gem 'selenium-webdriver'
-  gem 'timecop'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,6 @@ GEM
       net-ssh (>= 2.8.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -194,7 +193,6 @@ DEPENDENCIES
   rails (~> 5.2.0)
   selenium-webdriver
   sqlite3
-  timecop
   uglifier
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       rake (< 13.0)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    davenport (1.0.0)
+    davenport (1.0.2)
     erubi (1.8.0)
     execjs (2.7.0)
     faker (1.9.6)
@@ -198,4 +198,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -7,12 +7,36 @@ class Choice < ApplicationRecord
 
    attr_accessor :opening_date, :opening_time, :deadline_date, :deadline_time
 
+   def time_str(time)
+     time.strftime('%H:%M')
+   end
+
+   def date_str(date)
+     date.strftime('%Y-%m-%d')
+   end
+
+   def opening_date
+     @opening_date ||= date_str(Time.now.utc)
+   end
+
+   def opening_time
+     @opening_time ||= time_str(Time.now.utc)
+   end
+
+   def deadline_date
+     @deadline_date ||= date_str((Time.now + 1.day).utc)
+   end
+
+   def deadline_time
+     @deadline_time ||= time_str(Time.now.utc)
+   end
+
    validate :valid_title_and_description_lengths, :valid_alternative_count
    #apply_simple_captcha
    #validate :is_captcha_valid?, :only => [:new, :edit]
    validates_associated :alternatives
-   after_initialize :ensure_default_dates
-   before_validation :resolve_dates
+   after_find :populate_dates_and_times
+   after_initialize :resolve_dates
    token_column(:read_token, TOKEN_LENGTH)
    token_column(:edit_token, TOKEN_LENGTH)
 
@@ -22,24 +46,24 @@ class Choice < ApplicationRecord
 
    has_many :preferences, :dependent=>:destroy
 
-   def ensure_default_dates
-     self.opening ||= DateTime.current
-     self.opening_date = self.opening.to_date
-     self.opening_time = self.opening.to_time
-     self.deadline ||= 1.day.from_now
-     self.deadline_date = self.deadline.to_date
-     self.deadline_time = self.deadline.to_time
+   def populate_dates_and_times
+     self.opening_date = date_str(self.opening)
+     self.opening_time = time_str(self.opening)
+     self.deadline_date = date_str(self.deadline)
+     self.deadline_time = time_str(self.deadline)
    end
 
    def resolve_date_and_time(date_str, time_str)
      dd = date_str.to_datetime
-     dt = time_str.to_datetime.utc
-     DateTime.new(dd.year, dd.month, dd.day, dt.hour, dt.min, dt.sec)
+     dt = time_str.to_datetime
+     DateTime.new(dd.year, dd.month, dd.day, dt.hour, dt.min)
    end
 
    def resolve_dates
-     self.opening = resolve_date_and_time(opening_date, opening_time)
-     self.deadline = resolve_date_and_time(deadline_date, deadline_time)
+     self.opening ||= resolve_date_and_time(
+       self.opening_date, self.opening_time)
+     self.deadline ||= resolve_date_and_time(
+       self.deadline_date, self.deadline_time)
    end
 
    def valid_alternative_count

--- a/test/helpers/choice_helper.rb
+++ b/test/helpers/choice_helper.rb
@@ -28,14 +28,15 @@ module ChoiceHelper
   end
 
   def choice_params(choice)
+    choice.populate_dates_and_times
     {
       choice: {
         title: choice.title,
         description: choice.description,
-        opening_date: choice.opening.to_date,
-        opening_time: choice.opening.to_time,
-        deadline_date: choice.deadline.to_date,
-        deadline_time: choice.deadline.to_time,
+        opening_date: choice.opening_date,
+        opening_time: choice.opening_time,
+        deadline_date: choice.deadline_date,
+        deadline_time: choice.deadline_time,
         edit_token: choice.edit_token,
         read_token: choice.read_token,
         intermediate: choice.intermediate,

--- a/test/integration/choice/create_test.rb
+++ b/test/integration/choice/create_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Choice::CreateTest < ActionDispatch::IntegrationTest
+  include DateTimeDisplayHelper
+
   test 'records opt-in for show intermediate results' do
     get new_choice_path
     assert_response :success
@@ -51,21 +53,19 @@ class Choice::CreateTest < ActionDispatch::IntegrationTest
 
   test 'records selected opening date and time' do
     choice = create_full_choice
-    # TODO set an opening date
-    # TODO ensure choice_params codes the opening date params properly
+    choice.opening = Time.now - 3.days - 2.hours
     post choices_path(params: choice_params(choice))
     assert_response :redirect
     follow_redirect!
-    puts "PAGE #{@response.body}"
-    fail 'look for opening date match'
+    assert_match(datetime_full_display(choice.opening), @response.body)
   end
 
   test 'records selected deadline date and time' do
     choice = create_full_choice
-    # TODO set a deadline date
+    choice.deadline = Time.now + 1.week + 6.hours
     post choices_path(params: choice_params(choice))
     assert_response :redirect
     follow_redirect!
-    fail 'look for deadline match'
+    assert_match(datetime_full_display(choice.deadline), @response.body)
   end
 end

--- a/test/integration/choice/create_test.rb
+++ b/test/integration/choice/create_test.rb
@@ -48,4 +48,24 @@ class Choice::CreateTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_select 'li', 'Not shown publicly'
   end
+
+  test 'records selected opening date and time' do
+    choice = create_full_choice
+    # TODO set an opening date
+    # TODO ensure choice_params codes the opening date params properly
+    post choices_path(params: choice_params(choice))
+    assert_response :redirect
+    follow_redirect!
+    puts "PAGE #{@response.body}"
+    fail 'look for opening date match'
+  end
+
+  test 'records selected deadline date and time' do
+    choice = create_full_choice
+    # TODO set a deadline date
+    post choices_path(params: choice_params(choice))
+    assert_response :redirect
+    follow_redirect!
+    fail 'look for deadline match'
+  end
 end

--- a/test/models/choice/dates_test.rb
+++ b/test/models/choice/dates_test.rb
@@ -1,49 +1,37 @@
 require 'test_helper'
 
 class DatesTest < ActiveSupport::TestCase
+  DT_FORMAT = '%Y-%ms%d %H:%M %z'
+  D_FORMAT = '%Y-%m-%d'
+  T_FORMAT = '%H:%M'
+
   test 'create has default start and end dates' do
-    now = DateTime.current
-    Timecop.freeze now do
+    freeze_time do
+      now = Time.now.utc
       ch = create_full_choice
-      dt_format = '%Y:%m:%d:%H:%M:%S:%z'
-      d_format = '%Y:%m:%d'
-      t_format = '%H:%M:%S:%z'
-      assert_equal(now.strftime(dt_format), ch.opening.strftime(dt_format))
-      assert_equal(ch.opening.strftime(d_format),
-        ch.opening_date.strftime(d_format))
-      assert_equal(ch.opening.to_time.strftime(t_format),
-        ch.opening_time.strftime(t_format))
+      assert_equal(now.strftime(DT_FORMAT), ch.opening.strftime(DT_FORMAT))
+      assert_equal(ch.opening.strftime(D_FORMAT), ch.opening_date)
+      assert_equal(ch.opening.strftime(T_FORMAT), ch.opening_time)
       assert(now < ch.deadline)
-      assert(now.to_date < ch.deadline_date)
-      assert_equal(ch.deadline.strftime(d_format),
-        ch.deadline_date.strftime(d_format))
-      assert_equal(ch.deadline.to_time.strftime(t_format),
-        ch.deadline_time.strftime(t_format))
-      assert_equal(now.to_time.strftime(t_format),
-        ch.deadline_time.strftime(t_format))
+      assert_equal(ch.deadline.strftime(D_FORMAT), ch.deadline_date)
+      assert_equal(ch.deadline.strftime(T_FORMAT), ch.deadline_time)
     end
   end
 
   test 'save writes opening and deadline date and time' do
-    ts = DateTime.current + 1.day
-    te = DateTime.current + 2.days
+    ts = Time.now.utc + 1.day
+    te = Time.now.utc + 2.days
     ch = create_full_choice
-    ch.opening_date = Date.new(ts.year, ts.month, ts.day)
-    ch.opening_time = DateTime.new(ts.year, ts.month, ts.day, ts.hour, ts.minute)
-    ch.deadline_date = Date.new(te.year, te.month, te.day)
-    ch.deadline_time = DateTime.new(te.year, te.month, te.day, te.hour, te.minute)
+    ch.opening = ts
+    ch.deadline = te
     assert(ch.save)
     id = ch.id
     ch = Choice.find(id)
-    assert_equal(ts.hour, ch.opening.hour)
-    assert_equal(ts.min, ch.opening.min)
-    assert_equal(ts.day, ch.opening.day)
-    assert_equal(ts.month, ch.opening.month)
-    assert_equal(ts.year, ch.opening.year)
-    assert_equal(te.hour, ch.deadline.hour)
-    assert_equal(te.min, ch.deadline.min)
-    assert_equal(te.day, ch.deadline.day)
-    assert_equal(te.month, ch.deadline.month)
-    assert_equal(te.year, ch.deadline.year)
+    assert_equal(ts.strftime(DT_FORMAT), ch.opening.strftime(DT_FORMAT))
+    assert_equal(ts.strftime(D_FORMAT), ch.opening_date)
+    assert_equal(ts.strftime(T_FORMAT), ch.opening_time)
+    assert_equal(te.strftime(DT_FORMAT), ch.deadline.strftime(DT_FORMAT))
+    assert_equal(te.strftime(D_FORMAT), ch.deadline_date)
+    assert_equal(te.strftime(T_FORMAT), ch.deadline_time)
   end
 end


### PR DESCRIPTION
Closes #47 

Cleans-up the problem in which split date and time sent to the create method of the choices controller were overwritten with defaults.