### PR TITLE
Change wording of choice options prompts

### DIFF
--- a/app/views/choices/_form.html.erb
+++ b/app/views/choices/_form.html.erb
@@ -23,7 +23,7 @@
     <li>
       <%= f.check_box :intermediate %>
       <%= f.label :intermediate,
-        'Display intermediate result before deadline' %>
+        'Display intermediate result before the deadline' %>
     </li>
     <li>
       <%= f.check_box :public %>

--- a/app/views/choices/_form.html.erb
+++ b/app/views/choices/_form.html.erb
@@ -22,7 +22,8 @@
   <ul id='options', class="option-list">
     <li>
       <%= f.check_box :intermediate %>
-      <%= f.label :intermediate, 'Show intermediate result' %>
+      <%= f.label :intermediate,
+        'Display intermediate result before deadline' %>
     </li>
     <li>
       <%= f.check_box :public %>

--- a/app/views/choices/_form.html.erb
+++ b/app/views/choices/_form.html.erb
@@ -26,7 +26,8 @@
     </li>
     <li>
       <%= f.check_box :public %>
-      <%= f.label :public, 'Show publicly on main page' %>
+      <%= f.label :public,
+        "Request to place this question on the #{site_name} home page" %>
     </li>
   </ul>
 


### PR DESCRIPTION
Make the show intermediate and show publicly prompts less terse, more meaningful.