### PR TITLE
Show alternative descriptions in the page for preference expression

### DIFF
--- a/app/views/choices/_alternatives.html.erb
+++ b/app/views/choices/_alternatives.html.erb
@@ -1,0 +1,12 @@
+<div class="alternatives">
+  <% @choice.alternatives.each do |alt| %>
+    <div class="alternative">
+      <div class="alternativeTitle">
+        <%= alt.title %>
+      </div>
+      <div class="alternativeDescription">
+        <%= alt.description %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/choices/_display.html.erb
+++ b/app/views/choices/_display.html.erb
@@ -1,14 +1,3 @@
 <%= render :partial => 'choices/title' %>
 <%= render :partial => 'choices/options' %>
-<div class="alternatives">
-  <% @choice.alternatives.each do |alt| %>
-    <div class="alternative">
-      <div class="alternativeTitle">
-        <%= alt.title %>
-      </div>
-      <div class="alternativeDescription">
-        <%= alt.description %>
-      </div>
-    </div>
-  <% end %>
-</div>
+<%= render :partial => 'choices/alternatives' %>

--- a/app/views/choices/show.html.erb
+++ b/app/views/choices/show.html.erb
@@ -18,6 +18,7 @@
         :choice => @choice,
         :expression => @expression 
       } %>
+  <%= render :partial => 'choices/alternatives' %>
 <% else %>
   <p>This choice closed for selection
     <%= datetime_full_display(deadline) %>.


### PR DESCRIPTION
- Extracted the alternatives from the view that displays a choice into a partial.
- Used the partial to show the alternatives (with descriptions) below the interface for expressing the preference