### PR TITLE
Add columns for choice result computation state

### DIFF
--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -17,9 +17,23 @@ class Choice < ApplicationRecord
 
   has_many :preferences, :dependent=>:destroy
 
+  enum result_state: [
+    :computed, :dirty,
+    :computing, :computing_dirty
+  ], _prefix: :result
+  before_create :initialize_result_state
+
   def valid_alternative_count
    if alternatives.size < 2
      errors.add(:alternatives, "requires at least two alternatives")
    end
+  end
+
+  def initialize_result_state
+    self.result_state = "computed"
+  end
+
+  def result_parto
+    super || alternatives.collect(&:id).to_json
   end
 end

--- a/db/migrate/20191210183403_add_computation_state_to_choices.rb
+++ b/db/migrate/20191210183403_add_computation_state_to_choices.rb
@@ -1,0 +1,8 @@
+class AddComputationStateToChoices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :choices, :result_state, :integer
+    add_column :choices, :result_parto, :text
+
+    add_index :choices, :result_state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_23_012146) do
+ActiveRecord::Schema.define(version: 2019_12_10_183403) do
 
   create_table "alternatives", force: :cascade do |t|
     t.string "title", limit: 256, null: false
@@ -31,10 +31,28 @@ ActiveRecord::Schema.define(version: 2019_07_23_012146) do
     t.string "edit_token", limit: 32
     t.boolean "intermediate", default: false, null: false
     t.boolean "public", default: false, null: false
+    t.integer "result_state"
+    t.text "result_parto"
     t.index ["deadline"], name: "index_choices_on_deadline"
     t.index ["edit_token"], name: "index_choices_on_edit_token", unique: true
     t.index ["public"], name: "index_choices_on_public"
     t.index ["read_token"], name: "index_choices_on_read_token", unique: true
+    t.index ["result_state"], name: "index_choices_on_result_state"
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "expressions", force: :cascade do |t|

--- a/test/models/choice/result_test.rb
+++ b/test/models/choice/result_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ResultTest < ActiveSupport::TestCase
+  test 'new choice has good result' do
+    ch = create_full_choice
+    ch.save!
+    assert(ch.result_computed?)
+  end
+
+  test 'new choice returns no-order result' do
+    ch = create_full_choice
+    ch.save!
+    r = ch.result_parto
+    refute_nil(r)
+    ra = JSON.parse(r)
+    p = ch.alternatives.collect(&:id)
+    assert_equal(p.sort, ra.sort)
+  end
+end


### PR DESCRIPTION
Part of issue #71 

Adds columns to the choices table for result computation state and caching the computed result. Provides initialization of state on create and a default (no order) result.

This needs deployment prior to the migration that initializes the state for existing records, because that migration will rely on the code changes to the model, in particular, the enum column setter.